### PR TITLE
Fix: Changed handling of short hex colours.

### DIFF
--- a/jquery.tagcloud.js
+++ b/jquery.tagcloud.js
@@ -18,7 +18,7 @@
   // Converts hex to an RGB array
   var toRGB = function(code) {
     if (code.length === 4) {
-      code = jQuery.map(/\w+/.exec(code), function(el) {return el + el; }).join("");
+      code = code.replace(/(\w)(\w)(\w)/gi, "\$1\$1\$2\$2\$3\$3");
     }
     var hex = /(\w{2})(\w{2})(\w{2})/.exec(code);
     return [parseInt(hex[1], 16), parseInt(hex[2], 16), parseInt(hex[3], 16)];


### PR DESCRIPTION
Just a small change to yield more accurate colours when the user supplies a 3 character hex code.  

The existing code would convert #cde into #cdecde, which is actually a different colour when compared side by side.  This modified bit of code produces #ccddee, which shows up as an identical colour to the original 3 character version.  Tested in Firefox and Chrome - hopefully IE uses the same colour rendering logic for its css, too.
