### PR TITLE
add a simple option [background] default false

### DIFF
--- a/jquery.tagcloud.js
+++ b/jquery.tagcloud.js
@@ -80,13 +80,19 @@
         $(this).css({"font-size": opts.size.start + (weighting * fontIncr) + opts.size.unit});
       }
       if (opts.color) {
-        $(this).css({"color": tagColor(opts.color, colorIncr, weighting)});
+      	if(opts.background){
+      		$(this).css({"backgroundColor": tagColor(opts.color, colorIncr, weighting)});
+      	}else{
+      		$(this).css({"color": tagColor(opts.color, colorIncr, weighting)});
+      	}
+        
       }
     });
   };
 
   $.fn.tagcloud.defaults = {
-    size: {start: 14, end: 18, unit: "pt"}
+    size: {start: 14, end: 18, unit: "pt"},
+    background: false
   };
 
 })(jQuery);


### PR DESCRIPTION
give user the ability to choose where color apply to and backward compatible.

one advantage is background color is more highlighted.

default to false then won't affect current user after upgrade.

- true: apply color range to background color
- false: apply color range to font color

this is my post https://weiweitop.fun/tags/